### PR TITLE
Use proper Date when filtering updatedAt > x

### DIFF
--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
@@ -136,7 +136,7 @@ abstract class AbstractMongoSourceTask : SourceTask() {
 
     private fun getOffset(message: Document): Map<String, String> {
         val timestamp = message["ts"] as BsonTimestamp
-        val sortField = (message["o"] as Document)["updatedAt"] as String
+        val sortField = (message["o"] as Document)["updatedAt"].toString()
         val finishedImport = message["initialImport"] == null
         val offsetVal = MongoSourceOffset.toOffsetString(timestamp, sortField, finishedImport)
         return Collections.singletonMap(StructUtil.getDB(message), offsetVal)


### PR DESCRIPTION
Mongo is picky about type matching. If the `updatedAt >` query right hand side operand is a `String` or a `long` instead of a `Date`, it won't match anything. Tested this manually and it seems to be working as intended. We store the "offset" as an ISO date string in kafka and then parse into a `Date` when building our mongodb queries.