### PR TITLE
Remove EJSON date encoding with terrible regex hack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.reaction'
-version '1.9.0'
+version '1.10.0'
 
 buildscript {
     ext.kotlin_version = '1.2.60'

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
@@ -43,7 +43,6 @@ abstract class AbstractMongoSourceTask : SourceTask() {
     private var sleepTime = 50L
     private var maxSleepTime = 10000L
     private var analyzeSchema = false
-    private val ejsonDateAsLong: Regex = Regex("\\{ \"\\\$date\" : (\\d+) }")
 
     override fun version(): String = MongoSourceConnector().version()
     protected var unrecoverable: Throwable? = null
@@ -171,8 +170,7 @@ abstract class AbstractMongoSourceTask : SourceTask() {
         if (message["op"].toString() == "d") {
             struct.put("object", null)
         } else {
-            val json = ejsonDateAsLong.replace((message["o"] as Document).toJson(), "\$1")
-            struct.put("object", json)
+            struct.put("object", StructUtil.dateTimeAsMillis((message["o"] as Document).toJson()))
         }
         return struct
     }

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
@@ -43,6 +43,7 @@ abstract class AbstractMongoSourceTask : SourceTask() {
     private var sleepTime = 50L
     private var maxSleepTime = 10000L
     private var analyzeSchema = false
+    private val ejsonDateAsLong: Regex = Regex("\\{ \"\\\$date\" : (\\d+) }")
 
     override fun version(): String = MongoSourceConnector().version()
     protected var unrecoverable: Throwable? = null
@@ -170,7 +171,8 @@ abstract class AbstractMongoSourceTask : SourceTask() {
         if (message["op"].toString() == "d") {
             struct.put("object", null)
         } else {
-            struct.put("object", (message["o"] as Document).toJson())
+            val json = ejsonDateAsLong.replace((message["o"] as Document).toJson(), "\$1")
+            struct.put("object", json)
         }
         return struct
     }

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/source/StructUtil.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/source/StructUtil.kt
@@ -6,6 +6,8 @@ import org.bson.Document
  * @author Xu Jingxin
  */
 object StructUtil {
+    private val ejsonAsMillis = Regex("\\{\\s*\"\\\$date\"\\s*:\\s*(\\d+)\\s*}")
+
     fun getDB(message: Document): String {
         return message["ns"] as String
     }
@@ -13,5 +15,9 @@ object StructUtil {
     fun getTopic(message: Document, topicPrefix: String): String {
         val db = getDB(message).replace(".", "_")
         return topicPrefix + "_" + db
+    }
+
+    fun dateTimeAsMillis(json: String): String {
+      return ejsonAsMillis.replace(json, "\$1")
     }
 }

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/tools/ImportData.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/tools/ImportData.kt
@@ -116,6 +116,7 @@ class ImportDB(val uri: String,
     private val snakeDb: String = dbName.replace("\\.".toRegex(), "_")
     private var offsetCount = 0
     private val maxMessageSize = 3000
+    private val ejsonDateAsLong: Regex = Regex("\\{ \"\\\$date\" : (\\d+) }")
 
     companion object {
         private val log = LoggerFactory.getLogger(ImportDB::class.java)
@@ -214,7 +215,7 @@ class ImportDB(val uri: String,
                 "inc" to 0,
                 "database" to snakeDb,
                 "op" to "i",
-                "object" to document.toJson()
+                "object" to ejsonDateAsLong.replace(document.toJson(), "\$1")
             )))
         return MessageData(topic, key, message)
     }

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/tools/ImportData.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/tools/ImportData.kt
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory
 import java.io.FileInputStream
 import java.util.*
 import java.util.concurrent.ConcurrentLinkedQueue
+import com.teambition.kafka.connect.mongo.source.StructUtil;
 
 data class MessageData(val topic: String,
                        val key: JSONObject,
@@ -116,7 +117,6 @@ class ImportDB(val uri: String,
     private val snakeDb: String = dbName.replace("\\.".toRegex(), "_")
     private var offsetCount = 0
     private val maxMessageSize = 3000
-    private val ejsonDateAsLong: Regex = Regex("\\{ \"\\\$date\" : (\\d+) }")
 
     companion object {
         private val log = LoggerFactory.getLogger(ImportDB::class.java)
@@ -215,7 +215,7 @@ class ImportDB(val uri: String,
                 "inc" to 0,
                 "database" to snakeDb,
                 "op" to "i",
-                "object" to ejsonDateAsLong.replace(document.toJson(), "\$1")
+                "object" to StructUtil.dateTimeAsMillis(document.toJson())
             )))
         return MessageData(topic, key, message)
     }


### PR DESCRIPTION
This is a _terrible hack_.

:jack_o_lantern: 

**The Problem**

`org.bson.Document.toJSON()` by default will use Extended JSON (EJSON) encoding for DateTime values, which looks like `{ "updatedAt" : { "$date" : 1543444797655 } }`.

This is undesirable for 2 main reasons:

1. It's a non-standard and unusual JSON encoding schema not widely adopted outside of the mongodb/meteor community
2. GraphQL by default forbids property names containing the $ character

I looked into less hacky ways to achieve this including:

- Configuring the .toJson()` call to use `JsonMode.STRICT` , but this is actually the default and still does EJSON
- Trying to configured the `org.bson.json.JsonWriterSettings` with a different converter for DateTime, but the constructor that would allow that is private

I think this will actually work, but it's probably a bit fragile.
